### PR TITLE
smtlib: when reading model from z3, recognize negative numbers

### DIFF
--- a/lib/Smtlib.ml
+++ b/lib/Smtlib.ml
@@ -209,6 +209,7 @@ let rec sexp_to_term (sexp : sexp) : term = match sexp with
   | SBitVec (n, w) -> BitVec (n, w)
   | SBitVec64 n -> BitVec64 n
   | SSymbol x -> Const (Id x)
+  | SList (SSymbol "-" :: SInt x :: []) -> Int (-x)
   | _ -> failwith "unparsable term"
 
 let expect_success (solver : solver) (sexp : sexp) : unit =


### PR DESCRIPTION
Without this, the library throws an exception when Z3 graces us with a
model like:

```
(model
  (define-fun stack_base () Int
    (- 128))
  (define-fun stack_max () Int
    0)
)
```