### PR TITLE
Separate `build` from `install` for opam

### DIFF
--- a/opam
+++ b/opam
@@ -5,6 +5,8 @@ maintainer: "Arjun Guha <arjun@cs.umass.edu>"
 build: [
   ["./configure" "--prefix" prefix ]
   [make]
+]
+install: [
   [make "install"]
 ]
 remove: [


### PR DESCRIPTION
I think opam2 wants this so that the build step can have a "principle of least privilege" sandbox policy applied, i.e., it can't actually move files into their destination on the system.

For me, this fixed a problem where `opam install z3` (following the appropriate `opam pin` command) would error out with:

```
#=== ERROR while compiling z3.1.1.0 ===========================================#
# context     2.0.3 | macos/x86_64 | ocaml-system.4.07.1 | pinned(git+https://github.com/plasma-umass/ocaml-z3.git#34875fcc)
# path        ~/.opam/default/.opam-switch/build/z3.1.1.0
# command     ~/.opam/opam-init/hooks/sandbox.sh build make install
# exit-code   2
# env-file    ~/.opam/log/z3-533-d0f245.env
# output-file ~/.opam/log/z3-533-d0f245.out
### output ###
# ocaml setup.ml -install 
# ocamlfind: /Users/asampson/.opam/default/lib/z3/Smtlib.mli: Operation not permitted
# E: Failure("Command ''/Users/asampson/.opam/default/bin/ocamlfind' install z3 lib/META _build/lib/Smtlib.cmx _build/lib/Smtlib_syntax.cmx _build/lib/Smtlib_parser.cmx _build/lib/Smtlib_lexer.cmx _build/lib/Smtlib.annot _build/lib/Smtlib.cmt _build/lib/Smtlib.cmti _build/lib/Smtlib.cmi _build/lib/z3.cmxs _build/lib/z3.a _build/lib/z3.cmxa _build/lib/z3.cma lib/Smtlib.mli' terminated with error[...]
# make: *** [install] Error 1
```

Now everything works as expected.